### PR TITLE
feat: Add pitch-level and Statcast data collection (Phase 4)

### DIFF
--- a/src/mlb_stats/collectors/boxscore.py
+++ b/src/mlb_stats/collectors/boxscore.py
@@ -7,6 +7,7 @@ from typing import Callable
 
 from mlb_stats.api.client import MLBStatsClient
 from mlb_stats.collectors.game import sync_game
+from mlb_stats.collectors.play_by_play import sync_play_by_play
 from mlb_stats.collectors.schedule import fetch_schedule
 from mlb_stats.db.queries import (
     delete_game_batting,
@@ -66,7 +67,7 @@ def sync_boxscore(
     conn: sqlite3.Connection,
     game_pk: int,
 ) -> bool:
-    """Fetch boxscore and sync batting/pitching stats with player data.
+    """Fetch boxscore and sync all game stats including pitch-level data.
 
     Parameters
     ----------
@@ -92,6 +93,7 @@ def sync_boxscore(
     2. Extract and sync players from gameData.players
     3. Delete existing batting/pitching records for game
     4. Insert new batting/pitching records
+    5. Sync play-by-play (pitches, at-bats, batted balls)
     """
     logger.info("Syncing boxscore for game %d", game_pk)
 
@@ -174,6 +176,9 @@ def sync_boxscore(
             len(batting_rows),
             len(pitching_rows),
         )
+
+        # 6. Sync play-by-play (pitches, at-bats, batted balls)
+        sync_play_by_play(client, conn, game_pk)
 
         return True
 

--- a/src/mlb_stats/collectors/play_by_play.py
+++ b/src/mlb_stats/collectors/play_by_play.py
@@ -1,0 +1,198 @@
+"""Play-by-play data collector - orchestrates pitch, at-bat, and batted ball sync."""
+
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from typing import Callable
+
+from mlb_stats.api.client import MLBStatsClient
+from mlb_stats.db.queries import (
+    delete_at_bats,
+    delete_batted_balls,
+    delete_pitches,
+    get_game_pks_for_date_range,
+    upsert_at_bat,
+    upsert_batted_ball,
+    upsert_pitch,
+)
+from mlb_stats.models.pitch import (
+    extract_batted_ball_event,
+    extract_pitches_from_play,
+    transform_at_bat,
+    transform_batted_ball,
+    transform_pitch,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def sync_play_by_play(
+    client: MLBStatsClient,
+    conn: sqlite3.Connection,
+    game_pk: int,
+) -> bool:
+    """Fetch play-by-play and sync pitches, at-bats, and batted balls.
+
+    Parameters
+    ----------
+    client : MLBStatsClient
+        API client instance
+    conn : sqlite3.Connection
+        Database connection
+    game_pk : int
+        Game primary key
+
+    Returns
+    -------
+    bool
+        True if sync succeeded, False otherwise
+
+    Notes
+    -----
+    Uses game feed (already cached from boxscore sync) to get play data.
+
+    Order of operations (for foreign key compliance):
+    1. Fetch game feed
+    2. Validate game has play data
+    3. Delete existing pitch/at-bat/batted-ball records for idempotent sync
+    4. Insert at-bats, pitches, and batted balls
+    5. Commit transaction
+    """
+    logger.info("Syncing play-by-play for game %d", game_pk)
+
+    try:
+        fetched_at = datetime.now(timezone.utc).isoformat()
+
+        # Fetch game feed (already cached if Final from boxscore sync)
+        game_feed = client.get_game_feed(game_pk)
+
+        # Get plays from liveData
+        live_data = game_feed.get("liveData", {})
+        plays = live_data.get("plays", {})
+        all_plays = plays.get("allPlays", [])
+
+        if not all_plays:
+            logger.warning(
+                "No play data for game %d (game may not have started)",
+                game_pk,
+            )
+            return False
+
+        # Delete existing records for idempotent sync
+        # Order matters due to foreign key: batted_balls -> pitches
+        delete_batted_balls(conn, game_pk)
+        delete_pitches(conn, game_pk)
+        delete_at_bats(conn, game_pk)
+
+        # Track counts for logging
+        at_bat_count = 0
+        pitch_count = 0
+        batted_ball_count = 0
+
+        # Process each play
+        for play in all_plays:
+            # Skip incomplete plays that aren't at-bats
+            result_type = play.get("result", {}).get("type")
+            if result_type != "atBat":
+                continue
+
+            # Insert at-bat record
+            at_bat_row = transform_at_bat(play, game_pk, fetched_at)
+            upsert_at_bat(conn, at_bat_row)
+            at_bat_count += 1
+
+            # Get pitch events from this play
+            pitch_events = extract_pitches_from_play(play)
+
+            for event in pitch_events:
+                # Insert pitch record
+                pitch_row = transform_pitch(play, event, game_pk, fetched_at)
+                upsert_pitch(conn, pitch_row)
+                pitch_count += 1
+
+            # Check for batted ball (in-play event with hitData)
+            batted_ball_event = extract_batted_ball_event(play)
+            if batted_ball_event:
+                batted_ball_row = transform_batted_ball(
+                    play, batted_ball_event, game_pk, fetched_at
+                )
+                upsert_batted_ball(conn, batted_ball_row)
+                batted_ball_count += 1
+
+        conn.commit()
+
+        logger.info(
+            "Synced play-by-play for game %d: %d at-bats, %d pitches, %d batted balls",
+            game_pk,
+            at_bat_count,
+            pitch_count,
+            batted_ball_count,
+        )
+
+        return True
+
+    except Exception as e:
+        logger.error("Failed to sync play-by-play for game %d: %s", game_pk, e)
+        conn.rollback()
+        return False
+
+
+def sync_play_by_play_for_date_range(
+    client: MLBStatsClient,
+    conn: sqlite3.Connection,
+    start_date: str,
+    end_date: str,
+    progress_callback: Callable[[int, int], None] | None = None,
+) -> tuple[int, int]:
+    """Sync play-by-play for all games in date range.
+
+    Parameters
+    ----------
+    client : MLBStatsClient
+        API client instance
+    conn : sqlite3.Connection
+        Database connection
+    start_date : str
+        Start date (YYYY-MM-DD)
+    end_date : str
+        End date (YYYY-MM-DD)
+    progress_callback : callable, optional
+        Called with (current, total) for progress updates
+
+    Returns
+    -------
+    tuple[int, int]
+        (success_count, failure_count)
+
+    Notes
+    -----
+    Gets gamePks from database (assumes games are already synced).
+    """
+    # Get gamePks from database
+    game_pks = get_game_pks_for_date_range(conn, start_date, end_date)
+
+    if not game_pks:
+        logger.warning("No games found for date range %s to %s", start_date, end_date)
+        return (0, 0)
+
+    logger.info("Syncing play-by-play for %d games", len(game_pks))
+
+    success_count = 0
+    failure_count = 0
+
+    for i, game_pk in enumerate(game_pks):
+        if progress_callback:
+            progress_callback(i + 1, len(game_pks))
+
+        if sync_play_by_play(client, conn, game_pk):
+            success_count += 1
+        else:
+            failure_count += 1
+
+    logger.info(
+        "Play-by-play sync complete: %d succeeded, %d failed",
+        success_count,
+        failure_count,
+    )
+
+    return (success_count, failure_count)

--- a/src/mlb_stats/db/queries.py
+++ b/src/mlb_stats/db/queries.py
@@ -168,6 +168,96 @@ def delete_game_pitching(conn: sqlite3.Connection, gamePk: int) -> None:
     conn.execute("DELETE FROM game_pitching WHERE gamePk = ?", (gamePk,))
 
 
+def upsert_pitch(conn: sqlite3.Connection, row: dict) -> None:
+    """Insert or replace pitch record with write metadata.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection
+    row : dict
+        Pitch row data
+    """
+    row = row.copy()
+    row.update(get_write_metadata())
+    _upsert(conn, "pitches", row)
+
+
+def upsert_at_bat(conn: sqlite3.Connection, row: dict) -> None:
+    """Insert or replace at_bat record with write metadata.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection
+    row : dict
+        At-bat row data
+    """
+    row = row.copy()
+    row.update(get_write_metadata())
+    _upsert(conn, "at_bats", row)
+
+
+def upsert_batted_ball(conn: sqlite3.Connection, row: dict) -> None:
+    """Insert or replace batted_ball record with write metadata.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection
+    row : dict
+        Batted ball row data
+    """
+    row = row.copy()
+    row.update(get_write_metadata())
+    _upsert(conn, "batted_balls", row)
+
+
+def delete_pitches(conn: sqlite3.Connection, gamePk: int) -> None:
+    """Delete all pitch records for a game.
+
+    Used before re-inserting to ensure idempotent sync.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection
+    gamePk : int
+        Game primary key
+    """
+    conn.execute("DELETE FROM pitches WHERE gamePk = ?", (gamePk,))
+
+
+def delete_at_bats(conn: sqlite3.Connection, gamePk: int) -> None:
+    """Delete all at_bat records for a game.
+
+    Used before re-inserting to ensure idempotent sync.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection
+    gamePk : int
+        Game primary key
+    """
+    conn.execute("DELETE FROM at_bats WHERE gamePk = ?", (gamePk,))
+
+
+def delete_batted_balls(conn: sqlite3.Connection, gamePk: int) -> None:
+    """Delete all batted_ball records for a game.
+
+    Used before re-inserting to ensure idempotent sync.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection
+    gamePk : int
+        Game primary key
+    """
+    conn.execute("DELETE FROM batted_balls WHERE gamePk = ?", (gamePk,))
+
+
 def _upsert(conn: sqlite3.Connection, table: str, row: dict) -> None:
     """Generic INSERT OR REPLACE helper.
 

--- a/src/mlb_stats/models/pitch.py
+++ b/src/mlb_stats/models/pitch.py
@@ -1,0 +1,321 @@
+"""Pitch data transformation functions."""
+
+from typing import Any
+
+
+def transform_at_bat(
+    play: dict,
+    game_pk: int,
+    fetched_at: str,
+) -> dict:
+    """Transform a play to an at_bats table row.
+
+    Parameters
+    ----------
+    play : dict
+        Single play from allPlays array
+    game_pk : int
+        Game primary key
+    fetched_at : str
+        ISO8601 timestamp when data was fetched
+
+    Returns
+    -------
+    dict
+        Row dict for at_bats table
+    """
+    about = play.get("about", {})
+    result = play.get("result", {})
+    matchup = play.get("matchup", {})
+    count = play.get("count", {})
+
+    # Count pitches in this at-bat
+    play_events = play.get("playEvents", [])
+    pitch_count = sum(1 for e in play_events if e.get("isPitch"))
+
+    return {
+        "gamePk": game_pk,
+        "atBatIndex": about.get("atBatIndex"),
+        # Inning context
+        "inning": about.get("inning"),
+        "halfInning": about.get("halfInning"),
+        # Matchup
+        "batter_id": matchup.get("batter", {}).get("id"),
+        "pitcher_id": matchup.get("pitcher", {}).get("id"),
+        "batSide_code": matchup.get("batSide", {}).get("code"),
+        "pitchHand_code": matchup.get("pitchHand", {}).get("code"),
+        # Result
+        "event": result.get("event"),
+        "eventType": result.get("eventType"),
+        "description": result.get("description"),
+        # Scoring
+        "rbi": result.get("rbi"),
+        "awayScore": result.get("awayScore"),
+        "homeScore": result.get("homeScore"),
+        # At-bat details
+        "isComplete": _bool_to_int(about.get("isComplete")),
+        "hasReview": _bool_to_int(about.get("hasReview")),
+        "hasOut": _bool_to_int(about.get("hasOut")),
+        "isScoringPlay": _bool_to_int(about.get("isScoringPlay")),
+        # Count at end
+        "balls": count.get("balls"),
+        "strikes": count.get("strikes"),
+        "outs": count.get("outs"),
+        # Timing
+        "startTime": about.get("startTime"),
+        "endTime": about.get("endTime"),
+        # Pitch count
+        "pitchCount": pitch_count,
+        # Metadata
+        "_fetched_at": fetched_at,
+    }
+
+
+def transform_pitch(
+    play: dict,
+    event: dict,
+    game_pk: int,
+    fetched_at: str,
+) -> dict:
+    """Transform a pitch event to a pitches table row.
+
+    Parameters
+    ----------
+    play : dict
+        Parent play from allPlays array (for context)
+    event : dict
+        Single pitch event from playEvents array
+    game_pk : int
+        Game primary key
+    fetched_at : str
+        ISO8601 timestamp when data was fetched
+
+    Returns
+    -------
+    dict
+        Row dict for pitches table
+    """
+    about = play.get("about", {})
+    matchup = play.get("matchup", {})
+    details = event.get("details", {})
+    pitch_data = event.get("pitchData", {})
+    count = event.get("count", {})
+
+    # Extract coordinates
+    coordinates = pitch_data.get("coordinates", {})
+
+    # Extract break metrics
+    breaks = pitch_data.get("breaks", {})
+
+    # Pitch type from details
+    pitch_type = details.get("type", {})
+
+    # Call info
+    call = details.get("call", {})
+
+    return {
+        "gamePk": game_pk,
+        # At-bat context
+        "atBatIndex": about.get("atBatIndex"),
+        "pitchNumber": event.get("pitchNumber"),
+        # Inning context
+        "inning": about.get("inning"),
+        "halfInning": about.get("halfInning"),
+        # Matchup
+        "batter_id": matchup.get("batter", {}).get("id"),
+        "pitcher_id": matchup.get("pitcher", {}).get("id"),
+        # Batter/pitcher info at time of pitch
+        "batSide_code": matchup.get("batSide", {}).get("code"),
+        "pitchHand_code": matchup.get("pitchHand", {}).get("code"),
+        # Count before pitch
+        "balls": count.get("balls"),
+        "strikes": count.get("strikes"),
+        "outs": count.get("outs"),
+        # Pitch result
+        "call_code": call.get("code"),
+        "call_description": call.get("description"),
+        "isInPlay": _bool_to_int(details.get("isInPlay")),
+        "isStrike": _bool_to_int(details.get("isStrike")),
+        "isBall": _bool_to_int(details.get("isBall")),
+        # Pitch type
+        "type_code": pitch_type.get("code"),
+        "type_description": pitch_type.get("description"),
+        "typeConfidence": pitch_data.get("typeConfidence"),
+        # Pitch velocity
+        "startSpeed": pitch_data.get("startSpeed"),
+        "endSpeed": pitch_data.get("endSpeed"),
+        # Strike zone
+        "zone": pitch_data.get("zone"),
+        "strikeZoneTop": pitch_data.get("strikeZoneTop"),
+        "strikeZoneBottom": pitch_data.get("strikeZoneBottom"),
+        # Pitch location at plate (pX -> plateX, pZ -> plateZ)
+        "plateX": coordinates.get("pX"),
+        "plateZ": coordinates.get("pZ"),
+        # Pitch coordinates (legacy/display)
+        "coordinates_x": coordinates.get("x"),
+        "coordinates_y": coordinates.get("y"),
+        # Release point
+        "x0": coordinates.get("x0"),
+        "y0": coordinates.get("y0"),
+        "z0": coordinates.get("z0"),
+        # Initial velocity components
+        "vX0": coordinates.get("vX0"),
+        "vY0": coordinates.get("vY0"),
+        "vZ0": coordinates.get("vZ0"),
+        # Acceleration components
+        "aX": coordinates.get("aX"),
+        "aY": coordinates.get("aY"),
+        "aZ": coordinates.get("aZ"),
+        # Movement (PITCHf/x style)
+        "pfxX": coordinates.get("pfxX"),
+        "pfxZ": coordinates.get("pfxZ"),
+        # Statcast break metrics
+        "breakAngle": breaks.get("breakAngle"),
+        "breakLength": breaks.get("breakLength"),
+        "breakY": breaks.get("breakY"),
+        # Statcast spin metrics
+        "spinRate": breaks.get("spinRate"),
+        "spinDirection": breaks.get("spinDirection"),
+        # Statcast timing/extension
+        "plateTime": pitch_data.get("plateTime"),
+        "extension": pitch_data.get("extension"),
+        # Timestamps
+        "startTime": event.get("startTime"),
+        "endTime": event.get("endTime"),
+        # Metadata
+        "playId": event.get("playId"),
+        "_fetched_at": fetched_at,
+    }
+
+
+def transform_batted_ball(
+    play: dict,
+    event: dict,
+    game_pk: int,
+    fetched_at: str,
+) -> dict:
+    """Transform a batted ball event to a batted_balls table row.
+
+    Parameters
+    ----------
+    play : dict
+        Parent play from allPlays array (for result context)
+    event : dict
+        The pitch event that was put in play (must have hitData)
+    game_pk : int
+        Game primary key
+    fetched_at : str
+        ISO8601 timestamp when data was fetched
+
+    Returns
+    -------
+    dict
+        Row dict for batted_balls table
+    """
+    about = play.get("about", {})
+    result = play.get("result", {})
+    matchup = play.get("matchup", {})
+    hit_data = event.get("hitData", {})
+    hit_coords = hit_data.get("coordinates", {})
+
+    return {
+        "gamePk": game_pk,
+        # Link to pitch that was hit
+        "atBatIndex": about.get("atBatIndex"),
+        "pitchNumber": event.get("pitchNumber"),
+        # Matchup
+        "batter_id": matchup.get("batter", {}).get("id"),
+        "pitcher_id": matchup.get("pitcher", {}).get("id"),
+        # Inning context
+        "inning": about.get("inning"),
+        "halfInning": about.get("halfInning"),
+        # Statcast batted ball metrics
+        "launchSpeed": hit_data.get("launchSpeed"),
+        "launchAngle": hit_data.get("launchAngle"),
+        "totalDistance": hit_data.get("totalDistance"),
+        # Batted ball classification
+        "trajectory": hit_data.get("trajectory"),
+        "hardness": hit_data.get("hardness"),
+        # Field location
+        "location": hit_data.get("location"),
+        "coordinates_x": hit_coords.get("coordX"),
+        "coordinates_y": hit_coords.get("coordY"),
+        # Play result (from parent play)
+        "event": result.get("event"),
+        "eventType": result.get("eventType"),
+        "description": result.get("description"),
+        # Scoring impact
+        "rbi": result.get("rbi"),
+        "awayScore": result.get("awayScore"),
+        "homeScore": result.get("homeScore"),
+        # Calculated metrics (if available from API)
+        "hitProbability": hit_data.get("hitProbability"),
+        # Metadata
+        "playId": event.get("playId"),
+        "_fetched_at": fetched_at,
+    }
+
+
+def extract_pitches_from_play(play: dict) -> list[dict]:
+    """Extract pitch events from a play.
+
+    Parameters
+    ----------
+    play : dict
+        Single play from allPlays array
+
+    Returns
+    -------
+    list[dict]
+        List of pitch events (filtered by isPitch=True)
+
+    Notes
+    -----
+    Filters out non-pitch events like pickoffs, balks, etc.
+    """
+    events = play.get("playEvents", [])
+    return [e for e in events if e.get("isPitch")]
+
+
+def extract_batted_ball_event(play: dict) -> dict | None:
+    """Find the batted ball event in a play, if any.
+
+    Parameters
+    ----------
+    play : dict
+        Single play from allPlays array
+
+    Returns
+    -------
+    dict or None
+        The pitch event that was put in play with hitData, or None
+
+    Notes
+    -----
+    Looks for events where isInPlay=True and hitData exists.
+    Returns the last such event (the final pitch of the at-bat).
+    """
+    events = play.get("playEvents", [])
+    for event in reversed(events):
+        details = event.get("details", {})
+        if details.get("isInPlay") and event.get("hitData"):
+            return event
+    return None
+
+
+def _bool_to_int(value: Any) -> int | None:
+    """Convert boolean to integer (0/1) for SQLite.
+
+    Parameters
+    ----------
+    value : Any
+        Value to convert
+
+    Returns
+    -------
+    int or None
+        1 for True, 0 for False, None for None/missing
+    """
+    if value is None:
+        return None
+    return 1 if value else 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,7 +186,181 @@ def sample_game_feed() -> dict:
                     "away": {"teamStats": {}, "players": {}},
                     "home": {"teamStats": {}, "players": {}},
                 }
-            }
+            },
+            "plays": {
+                "allPlays": [
+                    {
+                        "result": {
+                            "type": "atBat",
+                            "event": "Strikeout",
+                            "eventType": "strikeout",
+                            "description": "Test Batter strikes out.",
+                            "rbi": 0,
+                            "awayScore": 0,
+                            "homeScore": 0,
+                        },
+                        "about": {
+                            "atBatIndex": 0,
+                            "halfInning": "top",
+                            "inning": 1,
+                            "startTime": "2024-07-02T02:15:00Z",
+                            "endTime": "2024-07-02T02:18:00Z",
+                            "isComplete": True,
+                            "isScoringPlay": False,
+                            "hasReview": False,
+                            "hasOut": True,
+                        },
+                        "count": {"balls": 1, "strikes": 3, "outs": 1},
+                        "matchup": {
+                            "batter": {"id": 660271, "fullName": "Shohei Ohtani"},
+                            "pitcher": {"id": 543243, "fullName": "Test Pitcher"},
+                            "batSide": {"code": "L"},
+                            "pitchHand": {"code": "R"},
+                        },
+                        "playEvents": [
+                            {
+                                "details": {
+                                    "call": {"code": "B", "description": "Ball"},
+                                    "isInPlay": False,
+                                    "isStrike": False,
+                                    "isBall": True,
+                                    "type": {"code": "FF", "description": "Fastball"},
+                                },
+                                "count": {"balls": 1, "strikes": 0, "outs": 0},
+                                "pitchData": {
+                                    "startSpeed": 95.0,
+                                    "endSpeed": 87.0,
+                                    "zone": 14,
+                                    "coordinates": {"pX": -1.5, "pZ": 3.3},
+                                    "breaks": {"spinRate": 2400, "spinDirection": 180},
+                                },
+                                "pitchNumber": 1,
+                                "playId": "test-pitch-1",
+                                "isPitch": True,
+                                "type": "pitch",
+                            },
+                            {
+                                "details": {
+                                    "call": {"code": "S", "description": "Strike"},
+                                    "isInPlay": False,
+                                    "isStrike": True,
+                                    "isBall": False,
+                                    "type": {"code": "SL", "description": "Slider"},
+                                },
+                                "count": {"balls": 1, "strikes": 1, "outs": 0},
+                                "pitchData": {"startSpeed": 87.0},
+                                "pitchNumber": 2,
+                                "playId": "test-pitch-2",
+                                "isPitch": True,
+                                "type": "pitch",
+                            },
+                            {
+                                "details": {
+                                    "call": {"code": "S", "description": "Strike"},
+                                    "isInPlay": False,
+                                    "isStrike": True,
+                                    "isBall": False,
+                                    "type": {"code": "FF", "description": "Fastball"},
+                                },
+                                "count": {"balls": 1, "strikes": 2, "outs": 0},
+                                "pitchData": {"startSpeed": 96.0},
+                                "pitchNumber": 3,
+                                "playId": "test-pitch-3",
+                                "isPitch": True,
+                                "type": "pitch",
+                            },
+                            {
+                                "details": {
+                                    "call": {"code": "S", "description": "Strike"},
+                                    "isInPlay": False,
+                                    "isStrike": True,
+                                    "isBall": False,
+                                    "type": {"code": "CH", "description": "Changeup"},
+                                },
+                                "count": {"balls": 1, "strikes": 3, "outs": 1},
+                                "pitchData": {"startSpeed": 85.0},
+                                "pitchNumber": 4,
+                                "playId": "test-pitch-4",
+                                "isPitch": True,
+                                "type": "pitch",
+                            },
+                        ],
+                    },
+                    {
+                        "result": {
+                            "type": "atBat",
+                            "event": "Single",
+                            "eventType": "single",
+                            "description": "Test Pitcher singles to left.",
+                            "rbi": 0,
+                            "awayScore": 0,
+                            "homeScore": 0,
+                        },
+                        "about": {
+                            "atBatIndex": 1,
+                            "halfInning": "bottom",
+                            "inning": 1,
+                            "startTime": "2024-07-02T02:25:00Z",
+                            "endTime": "2024-07-02T02:27:00Z",
+                            "isComplete": True,
+                            "isScoringPlay": False,
+                            "hasReview": False,
+                            "hasOut": False,
+                        },
+                        "count": {"balls": 1, "strikes": 0, "outs": 1},
+                        "matchup": {
+                            "batter": {"id": 543243, "fullName": "Test Pitcher"},
+                            "pitcher": {"id": 660271, "fullName": "Shohei Ohtani"},
+                            "batSide": {"code": "R"},
+                            "pitchHand": {"code": "R"},
+                        },
+                        "playEvents": [
+                            {
+                                "details": {
+                                    "call": {"code": "B", "description": "Ball"},
+                                    "isInPlay": False,
+                                    "isStrike": False,
+                                    "isBall": True,
+                                    "type": {"code": "FF", "description": "Fastball"},
+                                },
+                                "count": {"balls": 1, "strikes": 0, "outs": 1},
+                                "pitchData": {"startSpeed": 98.0},
+                                "pitchNumber": 1,
+                                "playId": "test-pitch-5",
+                                "isPitch": True,
+                                "type": "pitch",
+                            },
+                            {
+                                "details": {
+                                    "call": {"code": "X", "description": "In play"},
+                                    "isInPlay": True,
+                                    "isStrike": False,
+                                    "isBall": False,
+                                    "type": {"code": "FF", "description": "Fastball"},
+                                },
+                                "count": {"balls": 1, "strikes": 0, "outs": 1},
+                                "pitchData": {
+                                    "startSpeed": 97.5,
+                                    "coordinates": {"pX": 0.1, "pZ": 2.5},
+                                },
+                                "hitData": {
+                                    "launchSpeed": 95.0,
+                                    "launchAngle": 15,
+                                    "totalDistance": 250,
+                                    "trajectory": "line_drive",
+                                    "hardness": "hard",
+                                    "location": "7",
+                                    "coordinates": {"coordX": 80.0, "coordY": 120.0},
+                                },
+                                "pitchNumber": 2,
+                                "playId": "test-pitch-6",
+                                "isPitch": True,
+                                "type": "pitch",
+                            },
+                        ],
+                    },
+                ]
+            },
         },
     }
 
@@ -359,6 +533,317 @@ def sample_boxscore() -> dict:
                 "battingOrder": [],
             },
         }
+    }
+
+
+@pytest.fixture
+def sample_play() -> dict:
+    """Sample play (at-bat) from allPlays for testing.
+
+    Returns
+    -------
+    dict
+        Complete play structure with pitch events
+    """
+    return {
+        "result": {
+            "type": "atBat",
+            "event": "Strikeout",
+            "eventType": "strikeout",
+            "description": "Test Batter strikes out swinging.",
+            "rbi": 0,
+            "awayScore": 0,
+            "homeScore": 0,
+            "isOut": True,
+        },
+        "about": {
+            "atBatIndex": 0,
+            "halfInning": "top",
+            "isTopInning": True,
+            "inning": 1,
+            "startTime": "2024-07-02T02:15:00Z",
+            "endTime": "2024-07-02T02:18:00Z",
+            "isComplete": True,
+            "isScoringPlay": False,
+            "hasReview": False,
+            "hasOut": True,
+        },
+        "count": {
+            "balls": 1,
+            "strikes": 3,
+            "outs": 1,
+        },
+        "matchup": {
+            "batter": {"id": 660271, "fullName": "Shohei Ohtani"},
+            "pitcher": {"id": 543243, "fullName": "Test Pitcher"},
+            "batSide": {"code": "L", "description": "Left"},
+            "pitchHand": {"code": "R", "description": "Right"},
+        },
+        "playEvents": [
+            {
+                "details": {
+                    "call": {"code": "B", "description": "Ball"},
+                    "description": "Ball",
+                    "isInPlay": False,
+                    "isStrike": False,
+                    "isBall": True,
+                    "type": {"code": "FF", "description": "Four-Seam Fastball"},
+                },
+                "count": {"balls": 1, "strikes": 0, "outs": 0},
+                "pitchData": {
+                    "startSpeed": 95.2,
+                    "endSpeed": 87.1,
+                    "zone": 14,
+                    "strikeZoneTop": 3.49,
+                    "strikeZoneBottom": 1.6,
+                    "coordinates": {
+                        "x": 120.5,
+                        "y": 180.3,
+                        "pX": -1.45,
+                        "pZ": 3.31,
+                        "x0": -1.72,
+                        "y0": 50.0,
+                        "z0": 5.64,
+                        "vX0": 8.21,
+                        "vY0": -128.65,
+                        "vZ0": -6.34,
+                        "aX": 0.24,
+                        "aY": 27.1,
+                        "aZ": -31.21,
+                        "pfxX": -6.15,
+                        "pfxZ": 7.57,
+                    },
+                    "breaks": {
+                        "breakAngle": 3.6,
+                        "breakLength": 8.4,
+                        "breakY": 24.0,
+                        "spinRate": 2423,
+                        "spinDirection": 184,
+                    },
+                    "typeConfidence": 0.9,
+                    "plateTime": 0.43,
+                    "extension": 6.22,
+                },
+                "index": 0,
+                "playId": "pitch-1",
+                "pitchNumber": 1,
+                "startTime": "2024-07-02T02:15:00Z",
+                "endTime": "2024-07-02T02:15:05Z",
+                "isPitch": True,
+                "type": "pitch",
+            },
+            {
+                "details": {
+                    "call": {"code": "S", "description": "Swinging Strike"},
+                    "description": "Swinging Strike",
+                    "isInPlay": False,
+                    "isStrike": True,
+                    "isBall": False,
+                    "type": {"code": "SL", "description": "Slider"},
+                },
+                "count": {"balls": 1, "strikes": 1, "outs": 0},
+                "pitchData": {
+                    "startSpeed": 87.5,
+                    "endSpeed": 80.2,
+                    "zone": 6,
+                    "strikeZoneTop": 3.49,
+                    "strikeZoneBottom": 1.6,
+                    "coordinates": {
+                        "x": 115.0,
+                        "y": 175.0,
+                        "pX": 0.35,
+                        "pZ": 2.1,
+                    },
+                    "breaks": {
+                        "spinRate": 2650,
+                        "spinDirection": 45,
+                    },
+                    "typeConfidence": 0.85,
+                },
+                "index": 1,
+                "playId": "pitch-2",
+                "pitchNumber": 2,
+                "startTime": "2024-07-02T02:15:30Z",
+                "endTime": "2024-07-02T02:15:35Z",
+                "isPitch": True,
+                "type": "pitch",
+            },
+            {
+                "details": {
+                    "call": {"code": "S", "description": "Swinging Strike"},
+                    "description": "Swinging Strike",
+                    "isInPlay": False,
+                    "isStrike": True,
+                    "isBall": False,
+                    "type": {"code": "FF", "description": "Four-Seam Fastball"},
+                },
+                "count": {"balls": 1, "strikes": 2, "outs": 0},
+                "pitchData": {
+                    "startSpeed": 96.0,
+                    "endSpeed": 88.0,
+                    "zone": 5,
+                    "strikeZoneTop": 3.49,
+                    "strikeZoneBottom": 1.6,
+                    "coordinates": {
+                        "pX": 0.1,
+                        "pZ": 2.5,
+                    },
+                },
+                "index": 2,
+                "playId": "pitch-3",
+                "pitchNumber": 3,
+                "isPitch": True,
+                "type": "pitch",
+            },
+            {
+                "details": {
+                    "call": {"code": "S", "description": "Swinging Strike"},
+                    "description": "Swinging Strike",
+                    "isInPlay": False,
+                    "isStrike": True,
+                    "isBall": False,
+                    "type": {"code": "CH", "description": "Changeup"},
+                },
+                "count": {"balls": 1, "strikes": 3, "outs": 1},
+                "pitchData": {
+                    "startSpeed": 85.0,
+                    "endSpeed": 78.0,
+                    "zone": 6,
+                },
+                "index": 3,
+                "playId": "pitch-4",
+                "pitchNumber": 4,
+                "isPitch": True,
+                "type": "pitch",
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_play_with_hit() -> dict:
+    """Sample play with a ball put in play for testing batted ball data.
+
+    Returns
+    -------
+    dict
+        Play structure with hitData on the final pitch
+    """
+    return {
+        "result": {
+            "type": "atBat",
+            "event": "Single",
+            "eventType": "single",
+            "description": "Test Batter singles to left field.",
+            "rbi": 1,
+            "awayScore": 1,
+            "homeScore": 0,
+            "isOut": False,
+        },
+        "about": {
+            "atBatIndex": 5,
+            "halfInning": "top",
+            "isTopInning": True,
+            "inning": 2,
+            "startTime": "2024-07-02T02:30:00Z",
+            "endTime": "2024-07-02T02:32:00Z",
+            "isComplete": True,
+            "isScoringPlay": True,
+            "hasReview": False,
+            "hasOut": False,
+        },
+        "count": {
+            "balls": 2,
+            "strikes": 1,
+            "outs": 0,
+        },
+        "matchup": {
+            "batter": {"id": 660271, "fullName": "Shohei Ohtani"},
+            "pitcher": {"id": 543243, "fullName": "Test Pitcher"},
+            "batSide": {"code": "L", "description": "Left"},
+            "pitchHand": {"code": "R", "description": "Right"},
+        },
+        "playEvents": [
+            {
+                "details": {
+                    "call": {"code": "B", "description": "Ball"},
+                    "isInPlay": False,
+                    "isStrike": False,
+                    "isBall": True,
+                    "type": {"code": "FF", "description": "Four-Seam Fastball"},
+                },
+                "count": {"balls": 1, "strikes": 0, "outs": 0},
+                "pitchData": {"startSpeed": 94.5},
+                "pitchNumber": 1,
+                "isPitch": True,
+                "type": "pitch",
+            },
+            {
+                "details": {
+                    "call": {"code": "C", "description": "Called Strike"},
+                    "isInPlay": False,
+                    "isStrike": True,
+                    "isBall": False,
+                    "type": {"code": "SL", "description": "Slider"},
+                },
+                "count": {"balls": 1, "strikes": 1, "outs": 0},
+                "pitchData": {"startSpeed": 86.0},
+                "pitchNumber": 2,
+                "isPitch": True,
+                "type": "pitch",
+            },
+            {
+                "details": {
+                    "call": {"code": "B", "description": "Ball"},
+                    "isInPlay": False,
+                    "isStrike": False,
+                    "isBall": True,
+                    "type": {"code": "CH", "description": "Changeup"},
+                },
+                "count": {"balls": 2, "strikes": 1, "outs": 0},
+                "pitchData": {"startSpeed": 84.0},
+                "pitchNumber": 3,
+                "isPitch": True,
+                "type": "pitch",
+            },
+            {
+                "details": {
+                    "call": {"code": "X", "description": "In play, no out"},
+                    "description": "In play, no out",
+                    "isInPlay": True,
+                    "isStrike": False,
+                    "isBall": False,
+                    "type": {"code": "FF", "description": "Four-Seam Fastball"},
+                },
+                "count": {"balls": 2, "strikes": 1, "outs": 0},
+                "pitchData": {
+                    "startSpeed": 95.0,
+                    "endSpeed": 87.0,
+                    "zone": 5,
+                    "coordinates": {
+                        "pX": 0.2,
+                        "pZ": 2.8,
+                    },
+                },
+                "hitData": {
+                    "launchSpeed": 101.9,
+                    "launchAngle": 12,
+                    "totalDistance": 285,
+                    "trajectory": "line_drive",
+                    "hardness": "hard",
+                    "location": "7",
+                    "coordinates": {
+                        "coordX": 85.4,
+                        "coordY": 125.2,
+                    },
+                },
+                "index": 3,
+                "playId": "hit-pitch-1",
+                "pitchNumber": 4,
+                "isPitch": True,
+                "type": "pitch",
+            },
+        ],
     }
 
 

--- a/tests/integration/test_play_by_play_sync.py
+++ b/tests/integration/test_play_by_play_sync.py
@@ -1,0 +1,332 @@
+"""Integration tests for play-by-play sync functionality."""
+
+import sqlite3
+
+import responses
+
+from mlb_stats.api.client import MLBStatsClient
+from mlb_stats.api.endpoints import BASE_URL
+from mlb_stats.collectors.play_by_play import sync_play_by_play
+
+
+class TestSyncPlayByPlay:
+    """Tests for sync_play_by_play function."""
+
+    @responses.activate
+    def test_syncs_pitches_and_at_bats(
+        self,
+        temp_db: sqlite3.Connection,
+        mock_client: MLBStatsClient,
+        sample_game_feed: dict,
+    ) -> None:
+        """Test that sync_play_by_play creates pitch and at-bat records."""
+        # Mock game feed with play data
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}v1.1/game/745927/feed/live",
+            json=sample_game_feed,
+            status=200,
+        )
+
+        # First sync teams and players (required for foreign keys)
+        _setup_teams_and_players(temp_db)
+
+        result = sync_play_by_play(mock_client, temp_db, 745927)
+
+        assert result is True
+
+        # Verify at-bat records created (2 at-bats in sample)
+        cursor = temp_db.execute("SELECT COUNT(*) FROM at_bats WHERE gamePk = 745927")
+        at_bat_count = cursor.fetchone()[0]
+        assert at_bat_count == 2
+
+        # Verify pitch records created (6 pitches: 4 + 2)
+        cursor = temp_db.execute("SELECT COUNT(*) FROM pitches WHERE gamePk = 745927")
+        pitch_count = cursor.fetchone()[0]
+        assert pitch_count == 6
+
+        # Verify batted ball record created (1 ball in play)
+        cursor = temp_db.execute(
+            "SELECT COUNT(*) FROM batted_balls WHERE gamePk = 745927"
+        )
+        batted_ball_count = cursor.fetchone()[0]
+        assert batted_ball_count == 1
+
+    @responses.activate
+    def test_pitch_record_has_correct_data(
+        self,
+        temp_db: sqlite3.Connection,
+        mock_client: MLBStatsClient,
+        sample_game_feed: dict,
+    ) -> None:
+        """Test that pitch records have correct data."""
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}v1.1/game/745927/feed/live",
+            json=sample_game_feed,
+            status=200,
+        )
+
+        _setup_teams_and_players(temp_db)
+
+        sync_play_by_play(mock_client, temp_db, 745927)
+
+        # Check first pitch
+        cursor = temp_db.execute(
+            """
+            SELECT gamePk, atBatIndex, pitchNumber, inning, halfInning,
+                   batter_id, pitcher_id, call_code, type_code, startSpeed,
+                   spinRate, plateX, plateZ
+            FROM pitches
+            WHERE gamePk = 745927 AND atBatIndex = 0 AND pitchNumber = 1
+            """
+        )
+        row = cursor.fetchone()
+
+        assert row["gamePk"] == 745927
+        assert row["atBatIndex"] == 0
+        assert row["pitchNumber"] == 1
+        assert row["inning"] == 1
+        assert row["halfInning"] == "top"
+        assert row["batter_id"] == 660271
+        assert row["pitcher_id"] == 543243
+        assert row["call_code"] == "B"
+        assert row["type_code"] == "FF"
+        assert row["startSpeed"] == 95.0
+        assert row["spinRate"] == 2400
+        assert row["plateX"] == -1.5
+        assert row["plateZ"] == 3.3
+
+    @responses.activate
+    def test_at_bat_record_has_correct_data(
+        self,
+        temp_db: sqlite3.Connection,
+        mock_client: MLBStatsClient,
+        sample_game_feed: dict,
+    ) -> None:
+        """Test that at-bat records have correct data."""
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}v1.1/game/745927/feed/live",
+            json=sample_game_feed,
+            status=200,
+        )
+
+        _setup_teams_and_players(temp_db)
+
+        sync_play_by_play(mock_client, temp_db, 745927)
+
+        cursor = temp_db.execute(
+            """
+            SELECT gamePk, atBatIndex, inning, halfInning,
+                   batter_id, pitcher_id, event, eventType, pitchCount
+            FROM at_bats
+            WHERE gamePk = 745927 AND atBatIndex = 0
+            """
+        )
+        row = cursor.fetchone()
+
+        assert row["gamePk"] == 745927
+        assert row["atBatIndex"] == 0
+        assert row["inning"] == 1
+        assert row["halfInning"] == "top"
+        assert row["batter_id"] == 660271
+        assert row["pitcher_id"] == 543243
+        assert row["event"] == "Strikeout"
+        assert row["eventType"] == "strikeout"
+        assert row["pitchCount"] == 4
+
+    @responses.activate
+    def test_batted_ball_record_has_correct_data(
+        self,
+        temp_db: sqlite3.Connection,
+        mock_client: MLBStatsClient,
+        sample_game_feed: dict,
+    ) -> None:
+        """Test that batted ball records have correct data."""
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}v1.1/game/745927/feed/live",
+            json=sample_game_feed,
+            status=200,
+        )
+
+        _setup_teams_and_players(temp_db)
+
+        sync_play_by_play(mock_client, temp_db, 745927)
+
+        cursor = temp_db.execute(
+            """
+            SELECT gamePk, atBatIndex, pitchNumber, batter_id, pitcher_id,
+                   launchSpeed, launchAngle, totalDistance, trajectory, event
+            FROM batted_balls
+            WHERE gamePk = 745927
+            """
+        )
+        row = cursor.fetchone()
+
+        assert row["gamePk"] == 745927
+        assert row["atBatIndex"] == 1
+        assert row["pitchNumber"] == 2
+        assert row["batter_id"] == 543243
+        assert row["pitcher_id"] == 660271
+        assert row["launchSpeed"] == 95.0
+        assert row["launchAngle"] == 15
+        assert row["totalDistance"] == 250
+        assert row["trajectory"] == "line_drive"
+        assert row["event"] == "Single"
+
+    @responses.activate
+    def test_no_play_data_returns_false(
+        self,
+        temp_db: sqlite3.Connection,
+        mock_client: MLBStatsClient,
+    ) -> None:
+        """Test that empty play data returns False."""
+        game_feed = {
+            "gamePk": 745927,
+            "gameData": {},
+            "liveData": {"plays": {"allPlays": []}},
+        }
+
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}v1.1/game/745927/feed/live",
+            json=game_feed,
+            status=200,
+        )
+
+        result = sync_play_by_play(mock_client, temp_db, 745927)
+
+        assert result is False
+
+    @responses.activate
+    def test_includes_write_metadata(
+        self,
+        temp_db: sqlite3.Connection,
+        mock_client: MLBStatsClient,
+        sample_game_feed: dict,
+    ) -> None:
+        """Test that all records include write metadata."""
+        responses.add(
+            responses.GET,
+            f"{BASE_URL}v1.1/game/745927/feed/live",
+            json=sample_game_feed,
+            status=200,
+        )
+
+        _setup_teams_and_players(temp_db)
+
+        sync_play_by_play(mock_client, temp_db, 745927)
+
+        # Check pitch metadata
+        cursor = temp_db.execute(
+            """
+            SELECT _written_at, _git_hash, _version, _fetched_at
+            FROM pitches WHERE gamePk = 745927 LIMIT 1
+            """
+        )
+        row = cursor.fetchone()
+        assert row["_written_at"] is not None
+        assert row["_git_hash"] is not None
+        assert row["_version"] is not None
+        assert row["_fetched_at"] is not None
+
+        # Check at_bat metadata
+        cursor = temp_db.execute(
+            """
+            SELECT _written_at, _git_hash, _version, _fetched_at
+            FROM at_bats WHERE gamePk = 745927 LIMIT 1
+            """
+        )
+        row = cursor.fetchone()
+        assert row["_written_at"] is not None
+        assert row["_git_hash"] is not None
+        assert row["_version"] is not None
+        assert row["_fetched_at"] is not None
+
+        # Check batted_ball metadata
+        cursor = temp_db.execute(
+            """
+            SELECT _written_at, _git_hash, _version, _fetched_at
+            FROM batted_balls WHERE gamePk = 745927 LIMIT 1
+            """
+        )
+        row = cursor.fetchone()
+        assert row["_written_at"] is not None
+        assert row["_git_hash"] is not None
+        assert row["_version"] is not None
+        assert row["_fetched_at"] is not None
+
+
+class TestIdempotentPlayByPlaySync:
+    """Tests for idempotent re-sync behavior."""
+
+    @responses.activate
+    def test_resync_is_idempotent(
+        self,
+        temp_db: sqlite3.Connection,
+        mock_client: MLBStatsClient,
+        sample_game_feed: dict,
+    ) -> None:
+        """Test that re-syncing doesn't create duplicates."""
+        # Mock twice for two syncs
+        for _ in range(2):
+            responses.add(
+                responses.GET,
+                f"{BASE_URL}v1.1/game/745927/feed/live",
+                json=sample_game_feed,
+                status=200,
+            )
+
+        _setup_teams_and_players(temp_db)
+
+        # First sync
+        sync_play_by_play(mock_client, temp_db, 745927)
+
+        # Second sync
+        sync_play_by_play(mock_client, temp_db, 745927)
+
+        # Should still have same counts
+        cursor = temp_db.execute("SELECT COUNT(*) FROM at_bats WHERE gamePk = 745927")
+        assert cursor.fetchone()[0] == 2
+
+        cursor = temp_db.execute("SELECT COUNT(*) FROM pitches WHERE gamePk = 745927")
+        assert cursor.fetchone()[0] == 6
+
+        cursor = temp_db.execute(
+            "SELECT COUNT(*) FROM batted_balls WHERE gamePk = 745927"
+        )
+        assert cursor.fetchone()[0] == 1
+
+
+def _setup_teams_and_players(conn: sqlite3.Connection) -> None:
+    """Helper to set up required reference data for foreign keys."""
+    # Insert teams
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO teams (id, name, _fetched_at, _written_at, _git_hash, _version)
+        VALUES (137, 'San Francisco Giants', '2024-01-01', '2024-01-01', 'test', '1.0.0'),
+               (119, 'Los Angeles Dodgers', '2024-01-01', '2024-01-01', 'test', '1.0.0')
+        """
+    )
+
+    # Insert players
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO players (id, fullName, _fetched_at, _written_at, _git_hash, _version)
+        VALUES (660271, 'Shohei Ohtani', '2024-01-01', '2024-01-01', 'test', '1.0.0'),
+               (543243, 'Test Pitcher', '2024-01-01', '2024-01-01', 'test', '1.0.0')
+        """
+    )
+
+    # Insert game (required for pitch foreign key)
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO games (gamePk, season, gameType, gameDate, away_team_id, home_team_id,
+                                      _fetched_at, _written_at, _git_hash, _version)
+        VALUES (745927, 2024, 'R', '2024-07-01', 137, 119, '2024-01-01', '2024-01-01', 'test', '1.0.0')
+        """
+    )
+
+    conn.commit()

--- a/tests/unit/test_pitch_models.py
+++ b/tests/unit/test_pitch_models.py
@@ -1,0 +1,428 @@
+"""Tests for pitch transformation functions."""
+
+from mlb_stats.models.pitch import (
+    extract_batted_ball_event,
+    extract_pitches_from_play,
+    transform_at_bat,
+    transform_batted_ball,
+    transform_pitch,
+)
+
+
+class TestTransformAtBat:
+    """Tests for transform_at_bat function."""
+
+    def test_extracts_at_bat_data(self, sample_play: dict) -> None:
+        """Test extraction of at-bat data from play."""
+        row = transform_at_bat(sample_play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["gamePk"] == 745927
+        assert row["atBatIndex"] == 0
+        assert row["inning"] == 1
+        assert row["halfInning"] == "top"
+        assert row["_fetched_at"] == "2024-07-01T00:00:00Z"
+
+    def test_extracts_matchup(self, sample_play: dict) -> None:
+        """Test extraction of matchup data."""
+        row = transform_at_bat(sample_play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["batter_id"] == 660271
+        assert row["pitcher_id"] == 543243
+        assert row["batSide_code"] == "L"
+        assert row["pitchHand_code"] == "R"
+
+    def test_extracts_result(self, sample_play: dict) -> None:
+        """Test extraction of result data."""
+        row = transform_at_bat(sample_play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["event"] == "Strikeout"
+        assert row["eventType"] == "strikeout"
+        assert row["rbi"] == 0
+        assert row["awayScore"] == 0
+        assert row["homeScore"] == 0
+
+    def test_extracts_count(self, sample_play: dict) -> None:
+        """Test extraction of count at end of at-bat."""
+        row = transform_at_bat(sample_play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["balls"] == 1
+        assert row["strikes"] == 3
+        assert row["outs"] == 1
+
+    def test_counts_pitches(self, sample_play: dict) -> None:
+        """Test that pitch count is calculated correctly."""
+        row = transform_at_bat(sample_play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["pitchCount"] == 4  # 4 pitches in sample_play
+
+    def test_converts_booleans_to_int(self, sample_play: dict) -> None:
+        """Test that boolean fields are converted to int."""
+        row = transform_at_bat(sample_play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["isComplete"] == 1
+        assert row["isScoringPlay"] == 0
+        assert row["hasReview"] == 0
+        assert row["hasOut"] == 1
+
+    def test_extracts_timing(self, sample_play: dict) -> None:
+        """Test extraction of timing data."""
+        row = transform_at_bat(sample_play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["startTime"] == "2024-07-02T02:15:00Z"
+        assert row["endTime"] == "2024-07-02T02:18:00Z"
+
+    def test_handles_empty_play(self) -> None:
+        """Test handling of empty play data."""
+        play = {}
+        row = transform_at_bat(play, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["gamePk"] == 745927
+        assert row["atBatIndex"] is None
+        assert row["pitchCount"] == 0
+
+
+class TestTransformPitch:
+    """Tests for transform_pitch function."""
+
+    def test_extracts_pitch_data(self, sample_play: dict) -> None:
+        """Test extraction of pitch data from event."""
+        event = sample_play["playEvents"][0]  # First pitch
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["gamePk"] == 745927
+        assert row["atBatIndex"] == 0
+        assert row["pitchNumber"] == 1
+        assert row["inning"] == 1
+        assert row["halfInning"] == "top"
+
+    def test_extracts_matchup(self, sample_play: dict) -> None:
+        """Test extraction of matchup data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["batter_id"] == 660271
+        assert row["pitcher_id"] == 543243
+        assert row["batSide_code"] == "L"
+        assert row["pitchHand_code"] == "R"
+
+    def test_extracts_count(self, sample_play: dict) -> None:
+        """Test extraction of count before pitch."""
+        event = sample_play["playEvents"][1]  # Second pitch
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["balls"] == 1
+        assert row["strikes"] == 1
+        assert row["outs"] == 0
+
+    def test_extracts_call(self, sample_play: dict) -> None:
+        """Test extraction of pitch call."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["call_code"] == "B"
+        assert row["call_description"] == "Ball"
+        assert row["isInPlay"] == 0
+        assert row["isStrike"] == 0
+        assert row["isBall"] == 1
+
+    def test_extracts_pitch_type(self, sample_play: dict) -> None:
+        """Test extraction of pitch type."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["type_code"] == "FF"
+        assert row["type_description"] == "Four-Seam Fastball"
+        assert row["typeConfidence"] == 0.9
+
+    def test_extracts_velocity(self, sample_play: dict) -> None:
+        """Test extraction of velocity data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["startSpeed"] == 95.2
+        assert row["endSpeed"] == 87.1
+
+    def test_extracts_strike_zone(self, sample_play: dict) -> None:
+        """Test extraction of strike zone data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["zone"] == 14
+        assert row["strikeZoneTop"] == 3.49
+        assert row["strikeZoneBottom"] == 1.6
+
+    def test_extracts_plate_location(self, sample_play: dict) -> None:
+        """Test extraction of plate location (pX/pZ mapped to plateX/plateZ)."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["plateX"] == -1.45
+        assert row["plateZ"] == 3.31
+
+    def test_extracts_coordinates(self, sample_play: dict) -> None:
+        """Test extraction of legacy coordinates."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["coordinates_x"] == 120.5
+        assert row["coordinates_y"] == 180.3
+
+    def test_extracts_release_point(self, sample_play: dict) -> None:
+        """Test extraction of release point data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["x0"] == -1.72
+        assert row["y0"] == 50.0
+        assert row["z0"] == 5.64
+
+    def test_extracts_velocity_components(self, sample_play: dict) -> None:
+        """Test extraction of velocity component data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["vX0"] == 8.21
+        assert row["vY0"] == -128.65
+        assert row["vZ0"] == -6.34
+
+    def test_extracts_acceleration(self, sample_play: dict) -> None:
+        """Test extraction of acceleration data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["aX"] == 0.24
+        assert row["aY"] == 27.1
+        assert row["aZ"] == -31.21
+
+    def test_extracts_movement(self, sample_play: dict) -> None:
+        """Test extraction of movement data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["pfxX"] == -6.15
+        assert row["pfxZ"] == 7.57
+
+    def test_extracts_break_metrics(self, sample_play: dict) -> None:
+        """Test extraction of break metrics."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["breakAngle"] == 3.6
+        assert row["breakLength"] == 8.4
+        assert row["breakY"] == 24.0
+
+    def test_extracts_spin_metrics(self, sample_play: dict) -> None:
+        """Test extraction of spin metrics."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["spinRate"] == 2423
+        assert row["spinDirection"] == 184
+
+    def test_extracts_timing_extension(self, sample_play: dict) -> None:
+        """Test extraction of timing and extension data."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["plateTime"] == 0.43
+        assert row["extension"] == 6.22
+
+    def test_extracts_timestamps(self, sample_play: dict) -> None:
+        """Test extraction of timestamps."""
+        event = sample_play["playEvents"][0]
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        assert row["startTime"] == "2024-07-02T02:15:00Z"
+        assert row["endTime"] == "2024-07-02T02:15:05Z"
+        assert row["playId"] == "pitch-1"
+
+    def test_handles_missing_statcast_data(self, sample_play: dict) -> None:
+        """Test handling of pitch with missing Statcast data (pre-2015)."""
+        event = sample_play["playEvents"][3]  # Fourth pitch - minimal data
+        row = transform_pitch(sample_play, event, 745927, "2024-07-01T00:00:00Z")
+
+        # Core data should be present
+        assert row["pitchNumber"] == 4
+        assert row["startSpeed"] == 85.0
+
+        # Statcast fields should be None
+        assert row["spinRate"] is None
+        assert row["spinDirection"] is None
+        assert row["breakAngle"] is None
+        assert row["extension"] is None
+        assert row["plateX"] is None
+
+
+class TestTransformBattedBall:
+    """Tests for transform_batted_ball function."""
+
+    def test_extracts_batted_ball_data(self, sample_play_with_hit: dict) -> None:
+        """Test extraction of batted ball data."""
+        event = sample_play_with_hit["playEvents"][-1]  # Last pitch (in play)
+        row = transform_batted_ball(
+            sample_play_with_hit, event, 745927, "2024-07-01T00:00:00Z"
+        )
+
+        assert row["gamePk"] == 745927
+        assert row["atBatIndex"] == 5
+        assert row["pitchNumber"] == 4
+        assert row["_fetched_at"] == "2024-07-01T00:00:00Z"
+
+    def test_extracts_matchup(self, sample_play_with_hit: dict) -> None:
+        """Test extraction of matchup data."""
+        event = sample_play_with_hit["playEvents"][-1]
+        row = transform_batted_ball(
+            sample_play_with_hit, event, 745927, "2024-07-01T00:00:00Z"
+        )
+
+        assert row["batter_id"] == 660271
+        assert row["pitcher_id"] == 543243
+        assert row["inning"] == 2
+        assert row["halfInning"] == "top"
+
+    def test_extracts_statcast_metrics(self, sample_play_with_hit: dict) -> None:
+        """Test extraction of Statcast batted ball metrics."""
+        event = sample_play_with_hit["playEvents"][-1]
+        row = transform_batted_ball(
+            sample_play_with_hit, event, 745927, "2024-07-01T00:00:00Z"
+        )
+
+        assert row["launchSpeed"] == 101.9
+        assert row["launchAngle"] == 12
+        assert row["totalDistance"] == 285
+
+    def test_extracts_classification(self, sample_play_with_hit: dict) -> None:
+        """Test extraction of batted ball classification."""
+        event = sample_play_with_hit["playEvents"][-1]
+        row = transform_batted_ball(
+            sample_play_with_hit, event, 745927, "2024-07-01T00:00:00Z"
+        )
+
+        assert row["trajectory"] == "line_drive"
+        assert row["hardness"] == "hard"
+
+    def test_extracts_location(self, sample_play_with_hit: dict) -> None:
+        """Test extraction of field location data."""
+        event = sample_play_with_hit["playEvents"][-1]
+        row = transform_batted_ball(
+            sample_play_with_hit, event, 745927, "2024-07-01T00:00:00Z"
+        )
+
+        assert row["location"] == "7"  # Left field
+        assert row["coordinates_x"] == 85.4
+        assert row["coordinates_y"] == 125.2
+
+    def test_extracts_play_result(self, sample_play_with_hit: dict) -> None:
+        """Test extraction of play result from parent play."""
+        event = sample_play_with_hit["playEvents"][-1]
+        row = transform_batted_ball(
+            sample_play_with_hit, event, 745927, "2024-07-01T00:00:00Z"
+        )
+
+        assert row["event"] == "Single"
+        assert row["eventType"] == "single"
+        assert row["rbi"] == 1
+        assert row["awayScore"] == 1
+        assert row["homeScore"] == 0
+
+
+class TestExtractPitchesFromPlay:
+    """Tests for extract_pitches_from_play function."""
+
+    def test_extracts_all_pitches(self, sample_play: dict) -> None:
+        """Test extraction of all pitches from play."""
+        pitches = extract_pitches_from_play(sample_play)
+
+        assert len(pitches) == 4
+        assert all(p.get("isPitch") for p in pitches)
+
+    def test_excludes_non_pitch_events(self) -> None:
+        """Test that non-pitch events are excluded."""
+        play = {
+            "playEvents": [
+                {"isPitch": True, "pitchNumber": 1},
+                {"isPitch": False, "type": "action"},  # Pickoff
+                {"isPitch": True, "pitchNumber": 2},
+            ]
+        }
+        pitches = extract_pitches_from_play(play)
+
+        assert len(pitches) == 2
+        assert pitches[0]["pitchNumber"] == 1
+        assert pitches[1]["pitchNumber"] == 2
+
+    def test_handles_empty_play_events(self) -> None:
+        """Test handling of play with no events."""
+        play = {"playEvents": []}
+        pitches = extract_pitches_from_play(play)
+
+        assert pitches == []
+
+    def test_handles_missing_play_events(self) -> None:
+        """Test handling of play without playEvents key."""
+        play = {}
+        pitches = extract_pitches_from_play(play)
+
+        assert pitches == []
+
+
+class TestExtractBattedBallEvent:
+    """Tests for extract_batted_ball_event function."""
+
+    def test_finds_batted_ball_event(self, sample_play_with_hit: dict) -> None:
+        """Test finding batted ball event in play."""
+        event = extract_batted_ball_event(sample_play_with_hit)
+
+        assert event is not None
+        assert event["pitchNumber"] == 4
+        assert event["hitData"]["launchSpeed"] == 101.9
+
+    def test_returns_none_for_strikeout(self, sample_play: dict) -> None:
+        """Test that strikeout play has no batted ball event."""
+        event = extract_batted_ball_event(sample_play)
+
+        assert event is None
+
+    def test_handles_empty_play(self) -> None:
+        """Test handling of empty play."""
+        play = {}
+        event = extract_batted_ball_event(play)
+
+        assert event is None
+
+    def test_returns_last_in_play_event(self) -> None:
+        """Test that the last in-play event is returned."""
+        play = {
+            "playEvents": [
+                {
+                    "details": {"isInPlay": True},
+                    "hitData": {"launchSpeed": 90.0},
+                    "pitchNumber": 1,
+                },
+                {
+                    "details": {"isInPlay": True},
+                    "hitData": {"launchSpeed": 100.0},
+                    "pitchNumber": 2,
+                },
+            ]
+        }
+        event = extract_batted_ball_event(play)
+
+        assert event is not None
+        assert event["pitchNumber"] == 2
+        assert event["hitData"]["launchSpeed"] == 100.0
+
+    def test_requires_hit_data(self) -> None:
+        """Test that isInPlay without hitData returns None."""
+        play = {
+            "playEvents": [
+                {
+                    "details": {"isInPlay": True},
+                    # No hitData key
+                    "pitchNumber": 1,
+                },
+            ]
+        }
+        event = extract_batted_ball_event(play)
+
+        assert event is None


### PR DESCRIPTION
## Summary
- Implement complete play-by-play data sync including pitches, at-bats, and batted balls with full Statcast metrics
- Add `models/pitch.py` with transformation functions for pitch, at-bat, and batted ball data
- Add `collectors/play_by_play.py` to orchestrate the sync process
- Add query helpers for pitch/at-bat/batted-ball upsert/delete operations
- Integrate play-by-play sync into boxscore collector (runs automatically after boxscore sync)

## Test plan
- [x] 41 unit tests covering all transformation functions
- [x] 7 integration tests for end-to-end sync behavior
- [x] All 177 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)