### PR TITLE
Add season range support and extend --all to 2008

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,14 @@ Every table includes write metadata columns:
 - `_git_hash` - Git commit hash of code that wrote the row
 - `_version` - Semantic version of the application
 
+## Historical Data Eras
+
+- **2008-2014:** PITCHf/x era - pitch tracking without Statcast enhancements
+- **2015+:** Statcast era - full pitch and batted ball tracking
+- **Pre-2008:** Limited data - no pitch-level tracking available
+
+Pre-2015 games will have NULL values for Statcast-specific fields (`extension`, `plateTime`, `launchSpeed`, `launchAngle`, `totalDistance`).
+
 ## Write Metadata Pattern
 
 ```python

--- a/README.md
+++ b/README.md
@@ -58,8 +58,17 @@ uv run mlb-stats sync --start-date 2024-07-01 --end-date 2024-07-07
 # Sync all games for a season
 uv run mlb-stats sync --season 2024
 
-# Sync all data from 2015 to today (Statcast era)
+# Sync all data from 2008 to today (PITCHf/x era)
 uv run mlb-stats sync --all
+
+# Sync specific season range
+uv run mlb-stats sync --start-season 2010 --end-season 2015
+
+# Sync from 2018 to present
+uv run mlb-stats sync --start-season 2018
+
+# Sync from 2008 through 2020
+uv run mlb-stats sync --end-season 2020
 
 # Force refresh from API (ignore games already in database)
 uv run mlb-stats sync --season 2024 --force-refresh
@@ -69,6 +78,20 @@ uv run mlb-stats sync --all --force-refresh
 ```
 
 **Note:** The `--force-refresh` flag is useful when you have partial data in the database and want to fetch the complete schedule from the API. Without it, the sync will only process games already in the database for that date range.
+
+### Data Availability by Era
+
+| Year Range | Pitch Data | Batted Ball Statcast |
+|------------|------------|---------------------|
+| 2008-2014 | PITCHf/x (velocity, location, spin, break) | ❌ No exit velo/launch angle |
+| 2015+ | Statcast (PITCHf/x + extension, plateTime) | ✅ Yes (72-94% coverage) |
+
+Pre-2015 games will have NULL values for:
+- `extension` (pitcher release extension)
+- `plateTime` (time to reach plate)
+- `launchSpeed` (exit velocity)
+- `launchAngle` (launch angle)
+- `totalDistance` (hit distance)
 
 ### Global Options
 
@@ -101,8 +124,14 @@ uv run mlb-stats sync --start-date 2024-03-28 --end-date 2024-03-28
 # Sync the entire 2023 season (this will take a while)
 uv run mlb-stats sync --season 2023 --force-refresh
 
-# Sync all Statcast-era data (2015-present, ~30,000+ games)
+# Sync all PITCHf/x era data (2008-present, ~40,000+ games)
 uv run mlb-stats sync --all --force-refresh
+
+# Sync just the PITCHf/x-only era (before Statcast)
+uv run mlb-stats sync --start-season 2008 --end-season 2014
+
+# Sync a specific decade
+uv run mlb-stats sync --start-season 2010 --end-season 2019
 ```
 
 ### Querying the Database

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,130 @@
+"""Tests for CLI option validation."""
+
+import pytest
+from click.testing import CliRunner
+
+from mlb_stats.cli import cli
+
+
+@pytest.fixture
+def runner():
+    """Create a Click CLI runner."""
+    return CliRunner()
+
+
+class TestSeasonRangeValidation:
+    """Test validation for --start-season and --end-season options."""
+
+    def test_start_season_only(self, runner):
+        """Test --start-season alone defaults end to current year."""
+        result = runner.invoke(cli, ["sync", "--start-season", "2018", "--help"])
+        # Help should work without validation errors
+        assert result.exit_code == 0
+
+    def test_end_season_only(self, runner):
+        """Test --end-season alone defaults start to 2008."""
+        result = runner.invoke(cli, ["sync", "--end-season", "2020", "--help"])
+        assert result.exit_code == 0
+
+    def test_both_season_bounds(self, runner):
+        """Test --start-season and --end-season together."""
+        result = runner.invoke(
+            cli, ["sync", "--start-season", "2010", "--end-season", "2015", "--help"]
+        )
+        assert result.exit_code == 0
+
+    def test_start_after_end_error(self, runner):
+        """Test error when start season is after end season."""
+        result = runner.invoke(
+            cli, ["sync", "--start-season", "2020", "--end-season", "2018"]
+        )
+        assert result.exit_code != 0
+        assert "cannot be after" in result.output.lower()
+
+    def test_start_before_2008_error(self, runner):
+        """Test error when start season is before 2008."""
+        result = runner.invoke(cli, ["sync", "--start-season", "2005"])
+        assert result.exit_code != 0
+        assert "2008" in result.output
+        assert "PITCHf/x" in result.output
+
+    def test_season_range_with_date_range_error(self, runner):
+        """Test error when mixing season range with date range."""
+        result = runner.invoke(
+            cli,
+            [
+                "sync",
+                "--start-season",
+                "2010",
+                "--start-date",
+                "2024-01-01",
+                "--end-date",
+                "2024-01-31",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "cannot use" in result.output.lower()
+
+    def test_season_range_with_season_error(self, runner):
+        """Test error when mixing season range with --season."""
+        result = runner.invoke(
+            cli, ["sync", "--start-season", "2010", "--season", "2024"]
+        )
+        assert result.exit_code != 0
+        assert "cannot use" in result.output.lower()
+
+
+class TestAllFlagValidation:
+    """Test validation for --all flag."""
+
+    def test_all_with_start_season_error(self, runner):
+        """Test error when --all is used with --start-season."""
+        result = runner.invoke(cli, ["sync", "--all", "--start-season", "2010"])
+        assert result.exit_code != 0
+        assert "cannot use --all" in result.output.lower()
+
+    def test_all_with_end_season_error(self, runner):
+        """Test error when --all is used with --end-season."""
+        result = runner.invoke(cli, ["sync", "--all", "--end-season", "2020"])
+        assert result.exit_code != 0
+        assert "cannot use --all" in result.output.lower()
+
+    def test_all_with_season_error(self, runner):
+        """Test error when --all is used with --season."""
+        result = runner.invoke(cli, ["sync", "--all", "--season", "2024"])
+        assert result.exit_code != 0
+        assert "cannot use --all" in result.output.lower()
+
+    def test_all_with_date_range_error(self, runner):
+        """Test error when --all is used with date range."""
+        result = runner.invoke(
+            cli,
+            [
+                "sync",
+                "--all",
+                "--start-date",
+                "2024-01-01",
+                "--end-date",
+                "2024-01-31",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "cannot use --all" in result.output.lower()
+
+
+class TestGamePkValidation:
+    """Test validation for gamePk argument."""
+
+    def test_game_pk_with_season_range_error(self, runner):
+        """Test error when gamePk is used with season range."""
+        result = runner.invoke(
+            cli, ["sync", "745927", "--start-season", "2010", "--end-season", "2015"]
+        )
+        assert result.exit_code != 0
+        assert "cannot use gamepk" in result.output.lower()
+
+    def test_game_pk_with_all_error(self, runner):
+        """Test error when gamePk is used with --all."""
+        result = runner.invoke(cli, ["sync", "745927", "--all"])
+        assert result.exit_code != 0
+        assert "cannot use gamepk" in result.output.lower()


### PR DESCRIPTION
## Summary

Enhances the `sync` command to support flexible season ranges and extends historical data collection back to 2008 (PITCHf/x era).

## Changes

- Add `--start-season` and `--end-season` CLI options
- Update `--all` flag to sync from 2008 (PITCHf/x era) instead of 2015
- Add validation for season ranges (start > end, start < 2008)
- Add validation for mutual exclusivity with existing options
- Refactor sync loop into reusable `sync_season_range` helper
- Update README with new examples and data availability table
- Update CLAUDE.md with historical data eras section
- Add comprehensive CLI validation tests

Closes #9

Generated with [Claude Code](https://claude.ai/code)