### PR TITLE
Remove duplicate umpire fields from games table

### DIFF
--- a/docs/DATABASE_GUIDE.md
+++ b/docs/DATABASE_GUIDE.md
@@ -198,8 +198,6 @@ Venues are stored per-year to track changes between seasons (renovations, capaci
 | attendance | INTEGER | Crowd size |
 | doubleHeader | TEXT | Y/N/S |
 | gameNumber | INTEGER | 1 or 2 for doubleheaders |
-| umpire_HP_id | INTEGER | Home plate umpire ID |
-| umpire_HP_name | TEXT | Home plate umpire name |
 
 ### 5. `game_batting` - Per-Game Batting Stats
 
@@ -640,15 +638,16 @@ GROUP BY pit.pitchHand_code;
 ```sql
 -- Called strike rate by umpire
 SELECT
-    g.umpire_HP_name,
+    go.official_fullName as umpire_name,
     COUNT(*) as pitches_called,
     SUM(CASE WHEN p.call_code = 'C' THEN 1 ELSE 0 END) as called_strikes,
     ROUND(100.0 * SUM(CASE WHEN p.call_code = 'C' THEN 1 ELSE 0 END) / COUNT(*), 1) as K_rate
 FROM pitches p
 JOIN games g ON p.gamePk = g.gamePk
+JOIN game_officials go ON g.gamePk = go.gamePk AND go.officialType = 'Home Plate'
 WHERE p.call_code IN ('B', 'C')  -- Only called pitches (not swings)
   AND g.gameType = 'R'           -- Regular season only
-GROUP BY g.umpire_HP_id
+GROUP BY go.official_id
 HAVING COUNT(*) >= 200
 ORDER BY K_rate DESC;
 ```

--- a/docs/DATA_DICTIONARY.md
+++ b/docs/DATA_DICTIONARY.md
@@ -123,7 +123,6 @@ Core game information table. Cached only when game state is "Final".
 | seriesDescription | TEXT | Yes | `gameData.game.seriesDescription` | Series description |
 | seriesGameNumber | INTEGER | Yes | `gameData.game.seriesGameNumber` | Game number in series |
 | gamesInSeries | INTEGER | Yes | `gameData.game.gamesInSeries` | Total games in series |
-| umpire_HP_id | INTEGER | Yes | `liveData.boxscore.officials[type=Home Plate].official.id` | Home plate umpire ID (join to game_officials for name) |
 
 **Foreign Keys:**
 - `away_team_id` → `teams(id)`

--- a/src/mlb_stats/db/schema.py
+++ b/src/mlb_stats/db/schema.py
@@ -218,9 +218,6 @@ CREATE TABLE IF NOT EXISTS games (
     seriesGameNumber INTEGER,
     gamesInSeries INTEGER,
 
-    -- Home plate umpire (FK to game_officials for name lookup)
-    umpire_HP_id INTEGER,
-
     -- API fetch metadata
     _fetched_at TEXT NOT NULL,
 

--- a/src/mlb_stats/models/game.py
+++ b/src/mlb_stats/models/game.py
@@ -37,9 +37,6 @@ def transform_game(game_feed: dict, fetched_at: str) -> dict:
     boxscore = live_data.get("boxscore", {})
     boxscore_info = boxscore.get("info", [])
 
-    # Extract home plate umpire from officials
-    hp_umpire = _extract_home_plate_umpire(boxscore.get("officials", []))
-
     # Get final score from linescore
     linescore = live_data.get("linescore", {})
 
@@ -92,7 +89,6 @@ def transform_game(game_feed: dict, fetched_at: str) -> dict:
         "seriesDescription": game.get("seriesDescription"),
         "seriesGameNumber": game.get("seriesGameNumber"),
         "gamesInSeries": game.get("gamesInSeries"),
-        "umpire_HP_id": hp_umpire.get("id"),
         "_fetched_at": fetched_at,
     }
 


### PR DESCRIPTION
## Summary
- Remove `umpire_HP_id` from games table to eliminate data denormalization
- Canonical source for umpire data is now `game_officials` table only

## Changes
- Removed `umpire_HP_id` column from `games` table schema
- Removed `hp_umpire` extraction from `transform_game` function
- Updated `DATABASE_GUIDE.md` umpire query to use `game_officials` join
- Updated `DATA_DICTIONARY.md` to remove `umpire_HP_id` reference  
- Updated `PROJECT_PLAN.md` schema and example queries

## Migration
To get home plate umpire for a game, use:
```sql
SELECT go.official_fullName
FROM game_officials go
WHERE go.gamePk = ? AND go.officialType = 'Home Plate';
```

Closes #18

## Test plan
- [ ] Run existing tests to ensure no regressions
- [ ] Verify schema creates successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)